### PR TITLE
fix: Use correct env-vars in dockerfile to match what's provided in the .env file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,9 @@ ENV PORT=3000
 ENV HOST=0.0.0.0
 
 #Auth Lib
-ENV Auth_URL=http://localhost:8080
+ENV AUTH_URL=http://localhost:8080
 ENV KEYCLOAK_REALM=tazama
-ENV CERT_PATH=private_key.pem
+ENV CERT_PATH_PRIVATE=private_key.pem
 ENV CLIENT_SECRET=""
 ENV CLIENT_ID=""
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Use the correct env-var for auth url `AUTH_URL` and the certificate path `CERT_PATH_PRIVATE`. I

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
