### PR TITLE
build: undo change in package.json that caused build to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@fastify/cors": "^11.0.1",
-    "@tazama-lf/auth-lib": "^2.1.0",
+    "@tazama-lf/auth-lib": "^2.0.0",
     "@tazama-lf/auth-lib-provider-keycloak": "^1.0.0",
     "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
     "@tazama-lf/frms-coe-startup-lib": "2.4.0-rc.4",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Undo change in package.json that caused build to fail

## Why are we doing this?
The change was done in package.json but the package-lock.json wasn't updated because a new package wasn't published. There's already a pending change that will do that.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
