### PR TITLE
build: updated auth-lib-provider-keycloak version to 4.0.0-rc.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@tazama-lf/auth-lib": "4.0.0-rc.4",
-        "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.7",
+        "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.8",
         "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
         "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
         "ajv": "^8.17.1",
@@ -2160,9 +2160,9 @@
       }
     },
     "node_modules/@tazama-lf/auth-lib-provider-keycloak": {
-      "version": "4.0.0-rc.7",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib-provider-keycloak/4.0.0-rc.7/9b3c82942ce9cc55f5e175b5afe7d978549c8730",
-      "integrity": "sha512-mddq34mhHwIka7fmP3bLCLkJ6YHXmPnOzUSdlowdcbp0q6GcFWcTd1caRs7aexXiLEkEqfbDQVfu6CF6rOjJmw==",
+      "version": "4.0.0-rc.8",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib-provider-keycloak/4.0.0-rc.8/a37c1638ed72709039d9658e090f09a63a9070e4",
+      "integrity": "sha512-w+QdqSh32DBmssEa/Fu6urFSgEEnK0LgrfZTarAnYhTcH1xbZVlwBqgcbRgQyJJwX0fvhHAOEGUtUulaDCX7Kg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "^4.0.0-rc.4"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@fastify/cors": "^11.0.1",
     "@tazama-lf/auth-lib": "4.0.0-rc.4",
-    "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.7",
+    "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.8",
     "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
     "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
     "ajv": "^8.17.1",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Updated auth-lib-provider-keycloak version

## Why are we doing this?
To fix the Cross-Tenant issue on fetchUsers endpoint

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
