### PR TITLE
build: package update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/cors": "^11.0.1",
         "@tazama-lf/auth-lib": "4.0.0-rc.5",
-        "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.14",
+        "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.15",
         "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
         "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
         "ajv": "^8.17.1",
@@ -2160,9 +2160,9 @@
       }
     },
     "node_modules/@tazama-lf/auth-lib-provider-keycloak": {
-      "version": "4.0.0-rc.14",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib-provider-keycloak/4.0.0-rc.14/f2f09fe4aba7f567f84595974b3b3a8c908717ce",
-      "integrity": "sha512-CZYWbD+PoTy/tEi85Vyj0Wx3EeC29xIbvI59KE89iU8gwi24U/BKjkNysPijRS2R8iPn+CGRi4/hOMOI9tENdw==",
+      "version": "4.0.0-rc.15",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib-provider-keycloak/4.0.0-rc.15/3e50365b669015ff59456bb02652f97bb45340bf",
+      "integrity": "sha512-G7ZPar7Ezfe5BiwAXcbQbpjwSais1LqnP7L6zAXeiCAJWysP0I7uv9xEDCzuyDYJq9Qo/phZWRLQXNrwOdz+Cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/auth-lib": "4.0.0-rc.5"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@fastify/cors": "^11.0.1",
     "@tazama-lf/auth-lib": "4.0.0-rc.5",
-    "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.14",
+    "@tazama-lf/auth-lib-provider-keycloak": "4.0.0-rc.15",
     "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
     "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
     "ajv": "^8.17.1",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
auth-lib-provider-keycloak package version

## Why are we doing this?
Previous build was missing the change. So the issue persisted. Now resolved.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication library dependency to the latest release candidate version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->