### PR TITLE
ci: sync workflows from central-workflows [skip ci]

### DIFF
--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -18,6 +18,7 @@ on:
     branches: [ "main" ]
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   push_to_registry:
@@ -58,6 +59,7 @@ jobs:
           images: tazamaorg/${{ env.REPO_NAME }}
           tags: |
             type=raw,value=${{ steps.pkg_version.outputs.VERSION }}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
This PR syncs workflows from the central-workflows repository.

Signed-off-by: Sandy-at-Tazama <Sandy-at-Tazama@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually trigger Docker image builds.
  * Published Docker images now receive both version-specific and `latest` tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->